### PR TITLE
Add missing dependency: parse-torrent. Without this dependency, elect…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-react": "5.1.1",
     "eslint-plugin-standard": "1.3.2",
     "mkdirp": "0.5.1",
+    "parse-torrent": "^5.8.0",
     "rimraf": "2.5.2",
     "spectron": "3.0.0",
     "tape": "4.5.1"


### PR DESCRIPTION
…ron fails to launch via 'npm start'.
